### PR TITLE
Add Turnstile token execution to buy flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Serve up the instance of the app locally, using [Vite](https://vitejs.dev/).
 
 Vite expects the local HockeyPickup.Api to be listening on port `7042`. See [vite.config.mjs](vite.config.mjs).
 
+### Human verification
+
+The buy flow can submit Cloudflare Turnstile tokens when the API enables bot protection. Configure the app deployment with:
+
+```text
+VITE_TURNSTILE_SITE_KEY=<Cloudflare Turnstile site key>
+```
+
+Local development still works without this value when the API `BotProtection:Enabled` setting is `false`.
+
 ## 🎛️ Updating data models from the Api
 
 HockeyPickup.App uses very strict static typing, and data models referenced are generated from the Api using the OpenApi standard. To update the data models from the latest Api, simply run the `refresh-api` command to the Production or Local instance of the Api. This will update the [HockeyPickup.Api.ts](src/HockeyPickup.Api.ts) file.

--- a/index.html
+++ b/index.html
@@ -37,6 +37,11 @@
       gtag('js', new Date());
       gtag('config', 'G-295593998');
     </script>
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+      async
+      defer
+    ></script>
     <title>Hockey Pickup</title>
   </head>
   <body>

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -220,6 +220,17 @@
   transform: scale(1.05);
 }
 
+.turnstileContainer {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.turnstileContainer:empty {
+  margin-bottom: 0;
+}
+
 .mantine-Menu-item {
   color: var(--mantine-color-blue-4);
   font-weight: 500;

--- a/src/HockeyPickup.Api.ts
+++ b/src/HockeyPickup.Api.ts
@@ -815,6 +815,11 @@ export interface BuyRequest {
    * @maxLength 4000
    */
   Note?: string | null;
+  /**
+   * Human verification token for protected buy requests
+   * @maxLength 2048
+   */
+  HumanVerificationToken?: string | null;
 }
 
 export interface SellRequest {

--- a/src/components/SessionActions.tsx
+++ b/src/components/SessionActions.tsx
@@ -1,13 +1,15 @@
 import { SessionDetailedResponse } from '@/HockeyPickup.Api';
 import { useAuth } from '@/lib/auth';
 import { buySellService } from '@/lib/buysell';
+import { executeBuySpotVerification } from '@/lib/humanVerification';
 import { GET_SESSION } from '@/lib/queries';
 import { useQuery } from '@apollo/client/react';
 import { SessionQueryResult } from '@/types/graphql';
 import { Button, Group, Modal, Paper, Text, Textarea } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import moment from 'moment';
-import { JSX, useEffect, useState } from 'react';
+import { JSX, useEffect, useRef, useState } from 'react';
+import styles from '@/App.module.css';
 
 interface SessionActionsProps {
   session: SessionDetailedResponse;
@@ -28,6 +30,7 @@ export const SessionActions = ({ session, onSessionUpdate }: SessionActionsProps
   const [sellModalOpen, setSellModalOpen] = useState(false);
   const [note, setNote] = useState('');
   const [isTransacting, setIsTransacting] = useState(false);
+  const buyTurnstileContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const checkPermissions = async (): Promise<void> => {
@@ -69,9 +72,14 @@ export const SessionActions = ({ session, onSessionUpdate }: SessionActionsProps
     if (isTransacting) return;
     try {
       setIsTransacting(true);
+      const humanVerificationToken = await executeBuySpotVerification(
+        session.SessionId,
+        buyTurnstileContainerRef.current,
+      );
       const response = await buySellService.buySpot({
         SessionId: session.SessionId,
         Note: note,
+        HumanVerificationToken: humanVerificationToken,
       });
       const { data } = await refetch();
       if (data?.Session) {
@@ -193,6 +201,7 @@ export const SessionActions = ({ session, onSessionUpdate }: SessionActionsProps
           onChange={(event) => setNote(event.currentTarget.value)}
           mb='md'
         />
+        <div ref={buyTurnstileContainerRef} className={styles.turnstileContainer} />
         <Group justify='flex-end'>
           <Button
             variant='outline'
@@ -203,7 +212,7 @@ export const SessionActions = ({ session, onSessionUpdate }: SessionActionsProps
           >
             Cancel
           </Button>
-          <Button color='green' onClick={handleBuy}>
+          <Button color='green' onClick={handleBuy} loading={isTransacting}>
             Buy Spot
           </Button>
         </Group>

--- a/src/components/SessionActions.tsx
+++ b/src/components/SessionActions.tsx
@@ -201,6 +201,9 @@ export const SessionActions = ({ session, onSessionUpdate }: SessionActionsProps
           onChange={(event) => setNote(event.currentTarget.value)}
           mb='md'
         />
+        <Text size='xs' c='dimmed' mb='xs'>
+          Complete this check to complete your Buy Spot request.
+        </Text>
         <div ref={buyTurnstileContainerRef} className={styles.turnstileContainer} />
         <Group justify='flex-end'>
           <Button

--- a/src/lib/humanVerification.ts
+++ b/src/lib/humanVerification.ts
@@ -1,0 +1,75 @@
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+const TURNSTILE_ACTION = 'buy_spot';
+const TURNSTILE_LOAD_TIMEOUT_MS = 5000;
+const TURNSTILE_POLL_INTERVAL_MS = 50;
+
+export async function executeBuySpotVerification(
+  sessionId: number,
+  container: HTMLElement | null,
+): Promise<string | undefined> {
+  if (!TURNSTILE_SITE_KEY) {
+    return undefined;
+  }
+
+  if (!container) {
+    throw new Error('Human verification is unavailable. Please try again.');
+  }
+
+  const turnstile = await waitForTurnstile();
+  container.innerHTML = '';
+
+  let widgetId: string | undefined;
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      let settled = false;
+      const settle = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        callback();
+      };
+
+      const renderedWidgetId = turnstile.render(container, {
+        sitekey: TURNSTILE_SITE_KEY,
+        action: TURNSTILE_ACTION,
+        cData: `s_${sessionId}`,
+        execution: 'execute',
+        appearance: 'interaction-only',
+        callback: (token) => settle(() => resolve(token)),
+        'error-callback': () =>
+          settle(() => reject(new Error('Human verification failed. Please try again.'))),
+        'expired-callback': () =>
+          settle(() => reject(new Error('Human verification expired. Please try again.'))),
+      });
+
+      widgetId = renderedWidgetId;
+      turnstile.execute(renderedWidgetId);
+    });
+  } finally {
+    if (widgetId) {
+      turnstile.remove(widgetId);
+    }
+    container.innerHTML = '';
+  }
+}
+
+function waitForTurnstile(): Promise<Turnstile> {
+  if (window.turnstile) {
+    return Promise.resolve(window.turnstile);
+  }
+
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const intervalId = window.setInterval(() => {
+      if (window.turnstile) {
+        window.clearInterval(intervalId);
+        resolve(window.turnstile);
+        return;
+      }
+
+      if (Date.now() - startedAt >= TURNSTILE_LOAD_TIMEOUT_MS) {
+        window.clearInterval(intervalId);
+        reject(new Error('Human verification is unavailable. Please try again.'));
+      }
+    }, TURNSTILE_POLL_INTERVAL_MS);
+  });
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,3 +1,22 @@
 interface Window {
   gtag: (_command: string, _target: string, _config?: Record<string, unknown>) => void;
+  turnstile?: Turnstile;
+}
+
+interface Turnstile {
+  render: (_container: HTMLElement | string, _options: TurnstileRenderOptions) => string;
+  execute: (_widgetId: string) => void;
+  reset: (_widgetId: string) => void;
+  remove: (_widgetId: string) => void;
+}
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  action?: string;
+  cData?: string;
+  execution?: 'render' | 'execute';
+  appearance?: 'always' | 'execute' | 'interaction-only';
+  callback?: (_token: string) => void;
+  'error-callback'?: () => void;
+  'expired-callback'?: () => void;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_TURNSTILE_SITE_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

Adds Cloudflare Turnstile token execution to the buy modal so the app can submit human-verification tokens when the API enables bot protection.

Companion API PR: https://github.com/HockeyPickup/HockeyPickup.Api/pull/3

## What changed

- Loads Cloudflare Turnstile's explicit-render script in `index.html`.
- Adds `executeBuySpotVerification` to render and execute an interaction-only Turnstile widget for buy requests.
- Sends `HumanVerificationToken` with `BuyRequest`.
- Adds frontend Turnstile typings and `VITE_TURNSTILE_SITE_KEY` environment typing.
- Adds a small helper label above the Turnstile container so users know to complete the check when Cloudflare shows an interaction.
- Keeps local development working without `VITE_TURNSTILE_SITE_KEY` when the API has `BotProtection:Enabled = false`.

## Notes for reviewers

- The widget uses `appearance: "interaction-only"` and `execution: "execute"`, so most low-risk users should not see a visible challenge.
- The helper label is intentionally static and small; it only becomes meaningful when Cloudflare presents an interaction in the modal.
- The API must remain deployed with `BotProtection:Enabled = false` until this app is deployed with `VITE_TURNSTILE_SITE_KEY`.

## Rollout instructions

1. Merge/deploy the API PR first with `BotProtection:Enabled = false`.
2. Configure the app deployment with:
   - `VITE_TURNSTILE_SITE_KEY = <Cloudflare Turnstile site key>`
     - Get this from the Cloudflare dashboard: Turnstile -> the Hockey Pickup widget -> copy the public **sitekey**. Cloudflare's dashboard flow shows the sitekey/secret key pair when creating a widget; existing widgets can be managed from their widget details/settings. This value is safe for the frontend; do not use the secret key here. Reference: https://developers.cloudflare.com/turnstile/get-started/widget-management/dashboard/
3. Deploy this App PR.
4. Flip the API setting to `BotProtection:Enabled = true`.
5. Break-glass disablement remains on the API: set `BotProtection:Enabled = false`.

## Validation

- `./node_modules/.bin/eslint . --config eslint.config.cjs`
- `bash ./scripts/build-version.sh`
- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/vite build`
  - Passed. Vite emitted the existing large chunk size warning.

Note: global `yarn` is not currently on this machine's PATH, so I ran the same build steps through the repo's local binaries.

## Manual QA checklist

- Buy with a valid Turnstile test token.
- Buy with a reused token and confirm the API failure is surfaced in the notification.
- Buy after waiting past `MaxTokenAgeSeconds` and confirm the API failure is surfaced.
- Confirm sell flow is unaffected.
- Confirm local/dev behavior still works with `BotProtection:Enabled = false` and `VITE_TURNSTILE_SITE_KEY` unset.
